### PR TITLE
Basic Test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cover.out
+cover.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-cover.out
-cover.html
+coverage.txt
+coverage.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+
+sudo: false
+
+go:
+  - 1.5
+  - tip
+
+before_install:
+  # Redo the travis setup but with the pierre/gotestcover path. This is needed so the package path is correct
+  - mkdir -p $HOME/gopath/src/github.com/pierre/gotestcover
+  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/pierre/gotestcover
+  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/pierre/gotestcover
+  - cd $HOME/gopath/src/github.com/pierre/gotestcover
+
+install: make setup
+
+script:
+  - make check
+  - make coverage
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ go:
 
 before_install:
   # Redo the travis setup but with the pierre/gotestcover path. This is needed so the package path is correct
-  - mkdir -p $HOME/gopath/src/github.com/pierre/gotestcover
-  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/pierre/gotestcover
-  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/pierre/gotestcover
-  - cd $HOME/gopath/src/github.com/pierre/gotestcover
+  - mkdir -p $HOME/gopath/src/github.com/pierrre/gotestcover
+  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/pierrre/gotestcover
+  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/pierrre/gotestcover
+  - cd $HOME/gopath/src/github.com/pierrre/gotestcover
 
 install: make setup
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 #/bin/bash
 
+setup:
+	go get -u -v github.com/golang/lint/golint
+	go get -v -t ./...
+
+check:
+	gofmt -d .
+	go tool vet .
+	golint
+
 coverage:
-	gotestcover -coverprofile=cover.out github.com/pierre/gotestcover
-	go tool cover -html=cover.out -o=cover.html
+	gotestcover -coverprofile=coverage.txt github.com/pierre/gotestcover
+	go tool cover -html=coverage.txt -o=coverage.html
 	
 clean:
-	-rm cover.html
-	-rm cover.out
+	-rm coverage.txt
+	-rm coverage.html
 	gofmt -w .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+#/bin/bash
+
+coverage:
+	gotestcover -coverprofile=cover.out github.com/pierre/gotestcover
+	go tool cover -html=cover.out -o=cover.html
+	
+clean:
+	-rm cover.html
+	-rm cover.out
+	gofmt -w .

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ check:
 	golint
 
 coverage:
-	gotestcover -coverprofile=coverage.txt github.com/pierre/gotestcover
+	gotestcover -coverprofile=coverage.txt github.com/pierrre/gotestcover
 	go tool cover -html=coverage.txt -o=coverage.html
 	
 clean:

--- a/gotestcover_test.go
+++ b/gotestcover_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 )
@@ -24,17 +23,56 @@ func TestParseFlags(t *testing.T) {
 
 	err := parseFlags()
 
-	assert.Nil(t, err)
-	assert.True(t, flagVerbose)
-	assert.True(t, flagA)
-	assert.True(t, flagX)
-	assert.True(t, flagRace)
-	assert.Equal(t, "4", flagCPU)
-	assert.Equal(t, "2", flagParallel)
-	assert.Equal(t, "abc", flagRun)
-	assert.True(t, flagShort)
-	assert.Equal(t, "15", flagTimeout)
-	assert.Equal(t, "atomic", flagCoverMode)
-	assert.Equal(t, 2, flagParallelPackages)
-	assert.Equal(t, "cover.out", flagCoverProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !flagVerbose {
+		t.Errorf("flagVerbose should be set to true")
+	}
+
+	if !flagA {
+		t.Errorf("flagA should be set to true")
+	}
+
+	if !flagX {
+		t.Errorf("flagX should be set to true")
+	}
+
+	if !flagRace {
+		t.Errorf("flagRace should be set to true")
+	}
+
+	if flagCPU != "4" {
+		t.Errorf("flagCPU is not equal to 4, got %s", flagCPU)
+	}
+
+	if flagParallel != "2" {
+		t.Errorf("flagCPU is not equal to 2, got %s", flagParallel)
+	}
+
+	if flagRun != "abc" {
+		t.Errorf("flagRun is not equal to 'abc', got %s", flagRun)
+	}
+
+	if !flagShort {
+		t.Errorf("flagShort should be set to true")
+	}
+
+	if flagTimeout != "15" {
+		t.Errorf("flagTimeout is not equal to '15', got %s", flagTimeout)
+	}
+
+	if flagCoverMode != "atomic" {
+		t.Errorf("flagCoverMode is not equal to 'atomic', got %s", flagCoverMode)
+	}
+
+	if flagParallelPackages != 2 {
+		t.Errorf("flagParallelPackages is not equal to '2', got %s", flagParallelPackages)
+	}
+
+	if flagCoverProfile != "cover.out" {
+		t.Errorf("flagCoverProfile is not equal to 'cover.out', got %s", flagCoverProfile)
+	}
 }
+

--- a/gotestcover_test.go
+++ b/gotestcover_test.go
@@ -68,11 +68,10 @@ func TestParseFlags(t *testing.T) {
 	}
 
 	if flagParallelPackages != 2 {
-		t.Errorf("flagParallelPackages is not equal to '2', got %s", flagParallelPackages)
+		t.Errorf("flagParallelPackages is not equal to '2', got %d", flagParallelPackages)
 	}
 
 	if flagCoverProfile != "cover.out" {
 		t.Errorf("flagCoverProfile is not equal to 'cover.out', got %s", flagCoverProfile)
 	}
 }
-

--- a/gotestcover_test.go
+++ b/gotestcover_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestParseFlags(t *testing.T) {
+	os.Args = []string{"gotestcover",
+		"-v",
+		"-a",
+		"-x",
+		"-race",
+		"-cpu=4",
+		"-parallel=2",
+		"-run=abc",
+		"-short",
+		"-timeout=15",
+		"-covermode=atomic",
+		"-parallelpackages=2",
+		"-coverprofile=cover.out",
+	}
+
+	err := parseFlags()
+
+	assert.Nil(t, err)
+	assert.True(t, flagVerbose)
+	assert.True(t, flagA)
+	assert.True(t, flagX)
+	assert.True(t, flagRace)
+	assert.Equal(t, "4", flagCPU)
+	assert.Equal(t, "2", flagParallel)
+	assert.Equal(t, "abc", flagRun)
+	assert.True(t, flagShort)
+	assert.Equal(t, "15", flagTimeout)
+	assert.Equal(t, "atomic", flagCoverMode)
+	assert.Equal(t, 2, flagParallelPackages)
+	assert.Equal(t, "cover.out", flagCoverProfile)
+}

--- a/gotestcover_test.go
+++ b/gotestcover_test.go
@@ -15,7 +15,7 @@ func TestParseFlags(t *testing.T) {
 		"-parallel=2",
 		"-run=abc",
 		"-short",
-		"-timeout=15",
+		"-timeout=15s",
 		"-covermode=atomic",
 		"-parallelpackages=2",
 		"-coverprofile=cover.out",
@@ -59,8 +59,8 @@ func TestParseFlags(t *testing.T) {
 		t.Errorf("flagShort should be set to true")
 	}
 
-	if flagTimeout != "15" {
-		t.Errorf("flagTimeout is not equal to '15', got %s", flagTimeout)
+	if flagTimeout != "15s" {
+		t.Errorf("flagTimeout is not equal to '15s', got %s", flagTimeout)
 	}
 
 	if flagCoverMode != "atomic" {


### PR DESCRIPTION
A basic test environment to test gotestcover. The goal here is to "eat your own dog food". The current setup has one downside: Arguments can only read once which makes writing more test difficult. A solution to this can be found in a second step.

I suggest to run the build also on travis-ci and send the coverage to codecov.io. Like this we directly see if gotestcover works as expected.