### PR TITLE
add -coverpkg support

### DIFF
--- a/gotestcover.go
+++ b/gotestcover.go
@@ -325,6 +325,7 @@ func (b blocksByStart) Less(i, j int) bool {
 }
 
 func mergeCoverProfiles(cov []byte) ([]byte, error) {
+	setMode := flagCoverMode == "set" || flagCoverMode == "" && !flagRace
 	block := make(map[profileBlock]int)
 
 	s := bufio.NewScanner(bytes.NewReader(cov))
@@ -355,9 +356,13 @@ func mergeCoverProfiles(cov []byte) ([]byte, error) {
 
 	var merged = bytes.NewBuffer(make([]byte, 0, len(cov)))
 	for _, k := range keys {
+		count := block[k]
+		if setMode && count > 0 {
+			count = 1
+		}
 		_, err := fmt.Fprintf(merged, "%s:%d.%d,%d.%d %d %d\n",
 			k.FileName, k.StartLine, k.StartCol,
-			k.EndLine, k.EndCol, k.NumStmt, block[k])
+			k.EndLine, k.EndCol, k.NumStmt, count)
 		if err != nil {
 			return nil, err
 		}

--- a/gotestcover.go
+++ b/gotestcover.go
@@ -30,6 +30,7 @@ var (
 	flagShort        bool
 	flagTimeout      string
 	flagCoverMode    string
+	flagCoverPkg     string
 	flagCoverProfile string
 
 	// custom
@@ -60,6 +61,12 @@ func run() error {
 	cov, failed := runAllPackageTests(pkgs, flagArgs, func(out string) {
 		fmt.Print(out)
 	})
+	merge := exec.Command("sh", "-c", "sort -k 3 -n -r | sort -s -k 1,2 -u")
+	merge.Stdin = bytes.NewReader(cov)
+	cov, err = merge.Output()
+	if err != nil {
+		return err
+	}
 	err = writeCoverProfile(cov)
 	if err != nil {
 		return err
@@ -84,6 +91,7 @@ func parseFlags() error {
 	flag.BoolVar(&flagShort, "short", flagShort, "see 'go test' help")
 	flag.StringVar(&flagTimeout, "timeout", flagTimeout, "see 'go test' help")
 	flag.StringVar(&flagCoverMode, "covermode", flagCoverMode, "see 'go test' help")
+	flag.StringVar(&flagCoverPkg, "coverpkg", flagCoverPkg, "see 'go test' help")
 	flag.StringVar(&flagCoverProfile, "coverprofile", flagCoverProfile, "see 'go test' help")
 
 	flag.IntVar(&flagParallelPackages, "parallelpackages", flagParallelPackages, "Number of package test run in parallel")
@@ -217,6 +225,9 @@ func runPackageTests(pkg string, flgs []string) (out string, cov []byte, err err
 	args = append(args, "-cover")
 	if flagCoverMode != "" {
 		args = append(args, "-covermode", flagCoverMode)
+	}
+	if flagCoverPkg != "" {
+		args = append(args, "-coverpkg", flagCoverPkg)
 	}
 	args = append(args, "-coverprofile", coverFile.Name())
 


### PR DESCRIPTION
This isn't portable (*NIX only), but it does it work. I just don't have time right now to rewrite it in pure Go.

Looks like this works correctly both when -coverpkg set to ./... or selected packages.

close #8 
